### PR TITLE
Test on Dataflow

### DIFF
--- a/.github/workflows/dispatch-push-event.yaml
+++ b/.github/workflows/dispatch-push-event.yaml
@@ -11,7 +11,6 @@ jobs:
     env:
       FEEDSTOCK_SPEC: "${{ github.repository }}"
       REF: "${{ github.ref }}"
-      IS_BETA: "${{ contains(github.ref, 'beta') }}"
     steps:
       - name: dispatch push event
         uses: peter-evans/repository-dispatch@v1
@@ -19,4 +18,4 @@ jobs:
           token: ${{ secrets.PANGEO_FORGE_BOT_TOKEN }}
           repository: pangeo-forge/registrar
           event-type: dispatch-push-event
-          client-payload: '{"feedstock_spec": "${{ env.FEEDSTOCK_SPEC }}", "ref": "${{ env.REF }}", "is_beta": "${{ env.IS_BETA }}"}'
+          client-payload: '{"feedstock_spec": "${{ env.FEEDSTOCK_SPEC }}", "ref": "${{ env.REF }}", "is_beta": "true"}'

--- a/feedstock/meta.yaml
+++ b/feedstock/meta.yaml
@@ -18,7 +18,7 @@ provenance:
     - name: "University of Maryland"
       description: >
         University of Maryland College Park Earth System Science Interdisciplinary Center
-        (ESSIC) and Cooperative Institute for Climate and Satellites (CICS)
+        (ESSIC) and Cooperative Institute for Climate and Satellites (CICS).
       roles:
         - producer
       url: http://gpcp.umd.edu/

--- a/feedstock/meta.yaml
+++ b/feedstock/meta.yaml
@@ -2,7 +2,7 @@ title: "Global Precipitation Climatology Project"
 description: >
   Global Precipitation Climatology Project (GPCP) Daily Version 1.3 gridded, merged ty
   satellite/gauge precipitation Climate data Record (CDR) from 1996 to present.
-pangeo_forge_version: "0.8.3"
+pangeo_forge_version: "0.9.0"
 pangeo_notebook_version: "2022.06.02"
 recipes:
   - id: gpcp

--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -4,7 +4,7 @@ from pangeo_forge_recipes.patterns import pattern_from_file_sequence, FileType
 from pangeo_forge_recipes.recipes import XarrayZarrRecipe
 
 # The GPCP files use an annoying naming convention which embeds the creation date in the file name.
-# e.g. https 1996/gpcp_v01r03_daily_d19961001_c20170530.nc
+# e.g., https 1996/gpcp_v01r03_daily_d19961001_c20170530.nc
 # This makes it very hard to create a deterministic function to generate the file names,
 # so instead we crawl the NCEI server.
 


### PR DESCRIPTION
As tracked in https://github.com/pangeo-forge/gpcp-feedstock/issues/2, we're seeing scheduler memory issues on Prefect for this recipe, which is disappointing!

I'm curious if this would succeed on Dataflow, but not immediately sure how to easily route production runs there, so starting with a PR (labeled `dev`, to route to Dataflow) to see if a recipe test will succeed there with the version of the `to_beam` compiler present in `0.8.3`. 